### PR TITLE
chore: add documentation site link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To quickly set up and run the Identity Resolver using the docker-compose.yaml fi
 docker compose up -d;
 ```
 
-For more detailed setup and configuration options, refer to the [Quick Start Guide](./app/README.md).
+For more detailed setup and configuration options, refer to the [documentation site](https://pyx-industries.github.io/pyx-identity-resolver/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It enables identity registry operators and identifier owners to register links t
 To quickly set up and run the Identity Resolver using the docker-compose.yaml file, execute the following command:
 
 ```bash
-docker compose up -d;
+docker compose up -d
 ```
 
 For more detailed setup and configuration options, refer to the [documentation site](https://pyx-industries.github.io/pyx-identity-resolver/).


### PR DESCRIPTION
This PR adds a link to the deployed documentation site to the readme.